### PR TITLE
ci: Add a lot of opinionated linters

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,69 @@
+default_language_version:
+    python: python3.11
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: check-ast
+      - id: check-builtin-literals
+      - id: check-docstring-first
+      - id: check-merge-conflict
+      - id: check-yaml
+      - id: check-toml
+      - id: debug-statements
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: name-tests-test
+  - repo: https://github.com/asottile/add-trailing-comma
+    rev: v3.1.0
+    hooks:
+      - id: add-trailing-comma
+        args: ["--py36-plus"]
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.13.0
+    hooks:
+      - id: pyupgrade
+        args: ["--py37-plus"]
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+        args: ["--profile", "black", "--filter-files"]
+  - repo: https://github.com/psf/black
+    rev: 23.9.1
+    hooks:
+      - id: black
+  - repo: https://github.com/asottile/blacken-docs
+    rev: 1.16.0
+    hooks:
+      - id: blacken-docs
+        additional_dependencies: [black==23.9.1]
+  - repo: https://github.com/pre-commit/pygrep-hooks
+    rev: v1.10.0
+    hooks:
+      - id: rst-backticks
+  - repo: https://github.com/tox-dev/tox-ini-fmt
+    rev: "1.3.1"
+    hooks:
+      - id: tox-ini-fmt
+        args: ["-p", "lint"]
+  - repo: https://github.com/PyCQA/flake8
+    rev: 6.1.0
+    hooks:
+      - id: flake8
+        additional_dependencies:
+          - flake8-bugbear==23.3.12
+          - flake8-comprehensions==3.11.1
+          - flake8-pytest-style==1.7.2
+          - flake8-unused-arguments==0.0.13
+          - flake8-noqa==1.3.1
+          - pep8-naming==0.13.3
+          - flake8-pyproject==1.2.3
+  - repo: https://github.com/PyCQA/doc8
+    rev: v1.1.1
+    hooks:
+      - id: doc8
+  - repo: meta
+    hooks:
+      - id: check-hooks-apply
+      - id: check-useless-excludes

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,10 @@ UNRELEASED
 * Require irc>=20.0.0
 * Convert to hatchling build system backend
 * Replace Travis CI with GitHub Actions
+* Use pre-commit for linter checks
+* Use black for code formatting
+* Use isort for import formatting
+* Add a number of flake8 plugins including bugbear
 
 v0.2.0
 ------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,19 +1,18 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 import datetime
 import importlib.metadata
 
 import sphinx_rtd_theme
 
 extensions = [
-    'sphinx.ext.autodoc',
-    'sphinx.ext.intersphinx',
-    'sphinx.ext.viewcode',
+    "sphinx.ext.autodoc",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.viewcode",
 ]
 
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/3', None),
-    'irc': ('https://python-irc.readthedocs.io/en/stable/', None),
+    "python": ("https://docs.python.org/3", None),
+    "irc": ("https://python-irc.readthedocs.io/en/stable/", None),
 }
 
 # General information about the project.
@@ -25,13 +24,13 @@ author = "Bryan Davis"
 _origin_date = datetime.date(2017, 2, 19)
 _today = datetime.date.today()
 
-copyright = f'{_origin_date.year}-{_today.year} {author} and contributors'
+copyright = f"{_origin_date.year}-{_today.year} {author} and contributors"
 release = version
 
-master_doc = 'index'
-pygments_style = 'sphinx'
-html_theme = 'sphinx_rtd_theme'
+master_doc = "index"
+pygments_style = "sphinx"
+html_theme = "sphinx_rtd_theme"
 html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
-html_static_path = ['_static']
+html_static_path = ["_static"]
 
-suppress_warnings = ['image.nonlocal_uri']
+suppress_warnings = ["image.nonlocal_uri"]

--- a/examples/nickserv.py
+++ b/examples/nickserv.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # This file is part of IRC Bot Behavior Bundle (IB3)
 # Copyright (C) 2017 Bryan Davis and contributors
@@ -23,11 +22,10 @@ from ib3 import Bot
 from ib3.auth import NickServ
 from ib3.connection import SSL
 
-
 logging.basicConfig(
     level=logging.DEBUG,
-    format='%(asctime)s %(name)s %(levelname)s: %(message)s',
-    datefmt='%Y-%m-%dT%H:%M:%SZ'
+    format="%(asctime)s %(name)s %(levelname)s: %(message)s",
+    datefmt="%Y-%m-%dT%H:%M:%SZ",
 )
 logging.captureWarnings(True)
 
@@ -36,31 +34,33 @@ class TestBot(NickServ, SSL, Bot):
     pass
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        description='Example bot with NickServ auth')
-    parser.add_argument('nick')
-    parser.add_argument('password')
-    parser.add_argument('channel')
+        description="Example bot with NickServ auth",
+    )
+    parser.add_argument("nick")
+    parser.add_argument("password")
+    parser.add_argument("channel")
     parser.add_argument(
-        '-u', '--username',
-        help='Account name if different than nick',
+        "-u",
+        "--username",
+        help="Account name if different than nick",
     )
     args = parser.parse_args()
 
     bot = TestBot(
-        server_list=[('irc.libera.chat', 6697)],
+        server_list=[("irc.libera.chat", 6697)],
         nickname=args.nick,
         realname=args.nick,
         username=args.username,
         ident_password=args.password,
-        channels=[args.channel]
+        channels=[args.channel],
     )
     try:
         bot.start()
     except KeyboardInterrupt:
-        bot.disconnect('KeyboardInterrupt!')
+        bot.disconnect("KeyboardInterrupt!")
     except Exception:
-        logging.getLogger('root').exception('Killed by unhandled exception')
-        bot.disconnect('Exception!')
+        logging.getLogger("root").exception("Killed by unhandled exception")
+        bot.disconnect("Exception!")
         raise SystemExit()

--- a/examples/saslbot.py
+++ b/examples/saslbot.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # This file is part of IRC Bot Behavior Bundle (IB3)
 # Copyright (C) 2017 Bryan Davis and contributors
@@ -26,24 +25,24 @@ import ib3.auth
 import ib3.connection
 import ib3.nick
 
-
 logging.basicConfig(
     level=logging.DEBUG,
-    format='%(asctime)s %(name)s %(levelname)s: %(message)s',
-    datefmt='%Y-%m-%dT%H:%M:%SZ'
+    format="%(asctime)s %(name)s %(levelname)s: %(message)s",
+    datefmt="%Y-%m-%dT%H:%M:%SZ",
 )
 logging.captureWarnings(True)
 
-logger = logging.getLogger('saslbot')
+logger = logging.getLogger("saslbot")
 
 
 class SaslBot(ib3.auth.SASL, ib3.nick.Regain, ib3.connection.SSL, ib3.Bot):
     """Example bot showing use of SASL auth, REGAIN, and SSL encryption."""
+
     def on_privmsg(self, conn, event):
         self.do_command(conn, event, event.arguments[0])
 
     def on_pubmsg(self, conn, event):
-        args = event.arguments[0].split(':', 1)
+        args = event.arguments[0].split(":", 1)
         if len(args) > 1:
             to = irc.strings.lower(args[0])
             if to == irc.strings.lower(conn.get_nickname()):
@@ -54,27 +53,28 @@ class SaslBot(ib3.auth.SASL, ib3.nick.Regain, ib3.connection.SSL, ib3.Bot):
         if to == conn.get_nickname():
             to = event.source.nick
 
-        if cmd == 'disconnect':
+        if cmd == "disconnect":
             self.disconnect()
-        elif cmd == 'die':
+        elif cmd == "die":
             self.die()
         else:
-            conn.privmsg(to, 'What does "{}" mean?'.format(cmd))
+            conn.privmsg(to, f'What does "{cmd}" mean?')
 
 
-if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='Example bot with SASL auth')
-    parser.add_argument('nick')
-    parser.add_argument('password')
-    parser.add_argument('channel')
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Example bot with SASL auth")
+    parser.add_argument("nick")
+    parser.add_argument("password")
+    parser.add_argument("channel")
     parser.add_argument(
-        '-u', '--username',
-        help='Account name if different than nick',
+        "-u",
+        "--username",
+        help="Account name if different than nick",
     )
     args = parser.parse_args()
 
     bot = SaslBot(
-        server_list=[('irc.libera.chat', 6697)],
+        server_list=[("irc.libera.chat", 6697)],
         nickname=args.nick,
         realname=args.nick,
         username=args.username,
@@ -84,8 +84,8 @@ if __name__ == '__main__':
     try:
         bot.start()
     except KeyboardInterrupt:
-        bot.disconnect('KeyboardInterrupt!')
+        bot.disconnect("KeyboardInterrupt!")
     except Exception:
-        logger.exception('Killed by unhandled exception')
-        bot.disconnect('Exception!')
+        logger.exception("Killed by unhandled exception")
+        bot.disconnect("Exception!")
         raise SystemExit()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,3 +52,12 @@ build.targets.sdist.include = [
 
 [tool.hatch.version]
 source = "vcs"
+
+[tool.black]
+line_length = 88
+target_version = ["py37"]
+
+[tool.isort]
+known_first_party = ["ib3", "tests"]
+line_length = 88
+profile = "black"

--- a/src/ib3/__init__.py
+++ b/src/ib3/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # This file is part of IRC Bot Behavior Bundle (IB3)
 # Copyright (C) 2017 Bryan Davis and contributors
@@ -19,8 +18,8 @@
 import logging
 
 import irc.bot
-from jaraco.stream import buffer
 import irc.client
+from jaraco.stream import buffer
 
 logger = logging.getLogger(__name__)
 
@@ -32,11 +31,11 @@ class Bot(irc.bot.SingleServerIRCBot):
     UTF-8 encoding handling for inbound messages. This is a nice base to start
     from when adding other IB3 mixins.
     """
+
     def __init__(self, *args, **kwargs):
         # A UTF-8 only world is a nice dream but the real world is all yucky
         # and full of legacy encoding issues that should not crash our bot.
-        buffer.LenientDecodingLineBuffer.errors = 'replace'
-        irc.client.ServerConnection.buffer_class = \
-            buffer.LenientDecodingLineBuffer
+        buffer.LenientDecodingLineBuffer.errors = "replace"
+        irc.client.ServerConnection.buffer_class = buffer.LenientDecodingLineBuffer
 
-        super(Bot, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)

--- a/src/ib3/auth.py
+++ b/src/ib3/auth.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # This file is part of IRC Bot Behavior Bundle (IB3)
 # Copyright (C) 2017 Bryan Davis and contributors
@@ -28,9 +27,17 @@ logger = logging.getLogger(__name__)
 
 class AbstractAuth(JoinChannels):
     """Base class for authentication mixins."""
+
     def __init__(
-            self, server_list, nickname, realname,
-            ident_password, channels=[], username=None, **kwargs):
+        self,
+        server_list,
+        nickname,
+        realname,
+        ident_password,
+        channels=None,
+        username=None,
+        **kwargs,
+    ):
         """
         :param server_list: List of servers the bot will use.
         :param nickname: The bot's nickname
@@ -42,112 +49,128 @@ class AbstractAuth(JoinChannels):
         self._primary_nick = nickname
         self._username = username or nickname
         self._ident_password = ident_password
-        self._channels = channels
+        self._channels = channels or []
 
-        super(AbstractAuth, self).__init__(
-                server_list=server_list,
-                nickname=nickname,
-                realname=realname,
-                username=self._username,
-                **kwargs)
+        super().__init__(
+            server_list=server_list,
+            nickname=nickname,
+            realname=realname,
+            username=self._username,
+            **kwargs,
+        )
 
 
 class NickServ(AbstractAuth):
     """Authenticate with NickServ before joining channels."""
-    def __init__(self, *args, **kwargs):
-        super(NickServ, self).__init__(*args, **kwargs)
-        for event in ['welcome', 'privnotice']:
-            self.connection.add_global_handler(
-                event, getattr(self, "_handle_%s" % event))
 
-    def _handle_welcome(self, conn, event):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        for event in ["welcome", "privnotice"]:
+            self.connection.add_global_handler(
+                event,
+                getattr(self, f"_handle_{event}"),
+            )
+
+    def _handle_welcome(self, conn, event):  # noqa: U100 Unused argument
         """Handle WELCOME message.
 
         Starts authentication handshake by sending NickServ an ``identify``
         message.
         """
-        logger.info('Connected to server %s', conn.get_server_name())
+        logger.info("Connected to server %s", conn.get_server_name())
         self._identify_to_nickserv()
 
-    def _handle_privnotice(self, conn, event):
+    def _handle_privnotice(self, conn, event):  # noqa: U100 Unused argument
         """Handle NOTICE sent directly to user.
 
         Check for messages from NickServ requesting auth, warning of password
         failures, and acknowledging successful auth.
         """
         msg = event.arguments[0]
-        if event.source.nick == 'NickServ':
-            if 'NickServ identify' in msg:
-                logger.info('Authentication requested by Nickserv: %s', msg)
+        if event.source.nick == "NickServ":
+            if "NickServ identify" in msg:
+                logger.info("Authentication requested by Nickserv: %s", msg)
                 self._identify_to_nickserv()
-            elif 'You are now identified' in msg:
-                logger.debug('Authentication succeeded')
+            elif "You are now identified" in msg:
+                logger.debug("Authentication succeeded")
                 self.join_channels(self._channels)
-            elif 'Invalid password' in msg:
-                logger.error('Password invalid. Check your config!')
+            elif "Invalid password" in msg:
+                logger.error("Password invalid. Check your config!")
                 self.die()
 
     def _identify_to_nickserv(self):
         """Send NickServ our username and password."""
-        logger.info('Authenticating to NickServ')
-        self.connection.privmsg('NickServ', 'identify %s %s' % (
-            self._primary_nick, self._ident_password))
+        logger.info("Authenticating to NickServ")
+        self.connection.privmsg(
+            "NickServ",
+            "identify {} {}".format(
+                self._primary_nick,
+                self._ident_password,
+            ),
+        )
 
 
 class SASL(AbstractAuth):
     """Authenticate using SASL before joining channels."""
+
     def __init__(self, *args, **kwargs):
-        super(SASL, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         listen = {
-            'cap': 'cap',
-            'authenticate': 'authenticate',
-            'saslsuccess': irc.events.numeric.get('903', '903'),
-            'saslmechs': irc.events.numeric.get('908', '908'),
-            'welcome': 'welcome',
+            "cap": "cap",
+            "authenticate": "authenticate",
+            "saslsuccess": irc.events.numeric.get("903", "903"),
+            "saslmechs": irc.events.numeric.get("908", "908"),
+            "welcome": "welcome",
         }
 
         self.reactor._on_connect = self._handle_connect
 
         for handler, event in listen.items():
-            logger.debug('Registering for %s', event)
+            logger.debug("Registering for %s", event)
             self.connection.add_global_handler(
-                event, getattr(self, '_handle_%s' % handler))
+                event,
+                getattr(self, f"_handle_{handler}"),
+            )
 
-    def _handle_connect(self, sock):
+    def _handle_connect(self, sock):  # noqa: U100 Unused argument
         """Send CAP REQ :sasl on connect."""
-        self.connection.cap('REQ', 'sasl')
+        self.connection.cap("REQ", "sasl")
 
     def _handle_cap(self, conn, event):
         """Handle CAP responses."""
-        if event.arguments and event.arguments[0] == 'ACK':
-            conn.send_raw('AUTHENTICATE PLAIN')
+        if event.arguments and event.arguments[0] == "ACK":
+            conn.send_raw("AUTHENTICATE PLAIN")
         else:
-            logger.warning('Unexpected CAP response: %s', event)
+            logger.warning("Unexpected CAP response: %s", event)
             conn.disconnect()
 
     def _handle_authenticate(self, conn, event):
         """Handle AUTHENTICATE responses."""
-        if event.target == '+':
-            creds = '{username}\0{username}\0{password}'.format(
+        if event.target == "+":
+            creds = "{username}\0{username}\0{password}".format(
                 username=self._username,
-                password=self._ident_password)
-            conn.send_raw('AUTHENTICATE {}'.format(
-                    base64.b64encode(creds.encode('utf8')).decode('utf8')))
+                password=self._ident_password,
+            )
+            conn.send_raw(
+                "AUTHENTICATE {}".format(
+                    base64.b64encode(creds.encode("utf8")).decode("utf8"),
+                ),
+            )
         else:
-            logger.warning('Unexpected AUTHENTICATE response: %s', event)
+            logger.warning("Unexpected AUTHENTICATE response: %s", event)
             conn.disconnect()
 
-    def _handle_saslsuccess(self, conn, event):
+    def _handle_saslsuccess(self, conn, event):  # noqa: U100 Unused argument
         """Handle 903 RPL_SASLSUCCESS responses."""
-        self.connection.cap('END')
+        self.connection.cap("END")
 
-    def _handle_saslmechs(self, conn, event):
+    def _handle_saslmechs(self, conn, event):  # noqa: U100 Unused argument
         """Handle 908 RPL_SASLMECHS responses."""
-        logger.warning('SASL PLAIN not supported: %s', event)
+        logger.warning("SASL PLAIN not supported: %s", event)
         self.die()
 
-    def _handle_welcome(self, conn, event):
+    def _handle_welcome(self, conn, event):  # noqa: U100 Unused argument
         """Handle WELCOME message."""
-        logger.info('Connected to server %s', conn.get_server_name())
+        logger.info("Connected to server %s", conn.get_server_name())
         self.join_channels(self._channels)

--- a/src/ib3/connection.py
+++ b/src/ib3/connection.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # This file is part of IRC Bot Behavior Bundle (IB3)
 # Copyright (C) 2017 Bryan Davis and contributors
@@ -24,9 +23,11 @@ import irc.connection
 logger = logging.getLogger(__name__)
 
 
-class SSL(object):
+class SSL:
     """Use SSL connections."""
+
     def __init__(self, *args, **kwargs):
-        kwargs['connect_factory'] = irc.connection.Factory(
-            wrapper=ssl.wrap_socket)
-        super(SSL, self).__init__(*args, **kwargs)
+        kwargs["connect_factory"] = irc.connection.Factory(
+            wrapper=ssl.wrap_socket,
+        )
+        super().__init__(*args, **kwargs)

--- a/src/ib3/mixins.py
+++ b/src/ib3/mixins.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # This file is part of IRC Bot Behavior Bundle (IB3)
 # Copyright (C) 2017 Bryan Davis and contributors
@@ -24,90 +23,107 @@ import irc.client
 logger = logging.getLogger(__name__)
 
 
-class PingServer(object):
+class PingServer:
     """Add checks for connection liveness using PING commands."""
+
     def __init__(self, max_pings=2, ping_interval=300, *args, **kwargs):
         """
         :param max_pings: Maximum numer of missed pings to tolerate
         :param ping_interval: Seconds between ping attempts
         """
-        super(PingServer, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self._unanswered_pings = 0
         self._unanswered_pings_limit = max_pings
         self.reactor.scheduler.execute_every(
             period=ping_interval,
-            func=self._ping_server)
-        self.connection.add_global_handler('pong', self._handle_pong)
+            func=self._ping_server,
+        )
+        self.connection.add_global_handler("pong", self._handle_pong)
 
     def _ping_server(self):
         """Send a ping or disconnect if too many pings are outstanding."""
         if self._unanswered_pings >= self._unanswered_pings_limit:
-            logger.warning('Connection timed out. Disconnecting.')
+            logger.warning("Connection timed out. Disconnecting.")
             self.disconnect()
             self._unanswered_pings = 0
         else:
             try:
-                self.connection.ping('keep-alive')
+                self.connection.ping("keep-alive")
                 self._unanswered_pings += 1
             except irc.client.ServerNotConnectedError:
                 pass
 
-    def _handle_pong(self, conn, event):
+    def _handle_pong(self, conn, event):  # noqa: U100 Unused argument
         """Clear ping count when a pong is received."""
         self._unanswered_pings = 0
 
 
-class DisconnectOnError(object):
+class DisconnectOnError:
     """Handle ERROR message by logging and disconnecting."""
+
     def __init__(self, *args, **kwargs):
-        super(DisconnectOnError, self).__init__(*args, **kwargs)
-        self.connection.add_global_handler('error', self._handle_error)
+        super().__init__(*args, **kwargs)
+        self.connection.add_global_handler("error", self._handle_error)
 
     def _handle_error(self, conn, event):
         logger.warning(str(event))
         conn.disconnect()
 
 
-class RejoinOnKick(object):
+class RejoinOnKick:
     """Handle KICK by attempting to rejoin channel."""
+
     def __init__(self, *args, **kwargs):
-        super(RejoinOnKick, self).__init__(*args, **kwargs)
-        self.connection.add_global_handler('kick', self._handle_kick)
+        super().__init__(*args, **kwargs)
+        self.connection.add_global_handler("kick", self._handle_kick)
 
     def _handle_kick(self, conn, event):
         nick = event.arguments[0]
         channel = event.target
         if nick == conn.get_nickname():
             logger.warn(
-                'Kicked from %s by %s', channel, event.source.nick)
+                "Kicked from %s by %s",
+                channel,
+                event.source.nick,
+            )
             self.reactor.scheduler.execute_after(
-                30, functools.partial(conn.join, channel))
+                30,
+                functools.partial(conn.join, channel),
+            )
 
 
-class RejoinOnBan(object):
+class RejoinOnBan:
     """Handle ERR_BANNEDFROMCHAN by attempting to rejoin channel."""
+
     def __init__(self, *args, **kwargs):
         super(RejoinOnKick, self).__init__(*args, **kwargs)
         self.connection.add_global_handler(
-            'bannedfromchan', self._handle_bannedfromchan)
+            "bannedfromchan",
+            self._handle_bannedfromchan,
+        )
 
     def _handle_bannedfromchan(self, conn, event):
         logger.warning(str(event))
         self.reactor.scheduler.execute_after(
-            60, functools.partial(conn.join, event.arguments[0]))
+            60,
+            functools.partial(conn.join, event.arguments[0]),
+        )
 
 
-class JoinChannels(object):
+class JoinChannels:
     """Join channels one at a time to avoid flooding."""
+
     def join_channels(self, channels):
         """Join a list of channels, one at a time."""
         try:
             car, cdr = channels[0], channels[1:]
         except (IndexError, TypeError):
-            logger.exception('Failed to find channel to join.')
+            logger.exception("Failed to find channel to join.")
         else:
-            logger.info('Joining %s', car)
+            logger.info("Joining %s", car)
             self.connection.join(car)
             if cdr:
                 self.reactor.scheduler.execute_after(
-                    1, functools.partial(self.join_channels, cdr))
+                    1,
+                    functools.partial(self.join_channels, cdr),
+                )

--- a/src/ib3/nick.py
+++ b/src/ib3/nick.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # This file is part of IRC Bot Behavior Bundle (IB3)
 # Copyright (C) 2017 Bryan Davis and contributors
@@ -22,11 +21,18 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-class NicknameInUse(object):
+class NicknameInUse:
     """Handle ERR_NICKNAMEINUSE messages by changing to an alternate nick."""
+
     def __init__(
-            self, server_list, nickname, realname,
-            altnick=None, *args, **kwargs):
+        self,
+        server_list,
+        nickname,
+        realname,
+        altnick=None,
+        *args,  # noqa: U100 Unused argument
+        **kwargs,
+    ):
         """
         :param server_list: List of servers the bot will use.
         :param nickname: The bot's nickname
@@ -34,17 +40,20 @@ class NicknameInUse(object):
         :param altnick: Alternate nickname if primary nick is taken
         """
         self._primary_nick = nickname
-        self._altnick = altnick or nickname + '_'
+        self._altnick = altnick or nickname + "_"
 
-        super(NicknameInUse, self).__init__(
-                server_list=server_list,
-                nickname=nickname,
-                realname=realname,
-                **kwargs)
+        super().__init__(
+            server_list=server_list,
+            nickname=nickname,
+            realname=realname,
+            **kwargs,
+        )
         self.connection.add_global_handler(
-            'nicknameinuse', self._handle_nicknameinuse)
+            "nicknameinuse",
+            self._handle_nicknameinuse,
+        )
 
-    def _handle_nicknameinuse(self, conn, event):
+    def _handle_nicknameinuse(self, conn, event):  # noqa: U100 Unused argument
         """Handle ERR_NICKNAMEINUSE message.
 
         If failed nick matches our desired nick, switch to secondary nick, and
@@ -56,7 +65,8 @@ class NicknameInUse(object):
         logger.warning('Requested nick "%s" in use', nick)
         if nick == self._altnick:
             self.die(
-                'Cowardly refusing to fill the channel with copies of myself')
+                "Cowardly refusing to fill the channel with copies of myself",
+            )
         conn.nick(self._altnick)
         self.reactor.scheduler.execute_after(30, self._recover_nick)
 
@@ -83,14 +93,21 @@ class Ghost(NicknameInUse):
     This mixin assumes that you are also using a mixin from ``ib3.auth`` or
     another means to authenticate your IRC account.
     """
+
     def _recover_nick(self):
         """Recover nick by sending GHOST command to NickServ."""
         if not self.has_primary_nick():
             self.connection.privmsg(
-                'NickServ', 'GHOST {}'.format(self._primary_nick))
+                "NickServ",
+                f"GHOST {self._primary_nick}",
+            )
             self.reactor.scheduler.execute_after(
-                1, functools.partial(
-                    self.connection.nick, self._primary_nick))
+                1,
+                functools.partial(
+                    self.connection.nick,
+                    self._primary_nick,
+                ),
+            )
 
 
 class Regain(NicknameInUse):
@@ -102,8 +119,11 @@ class Regain(NicknameInUse):
     This mixin assumes that you are also using a mixin from ``ib3.auth`` or
     another means to authenticate your IRC account.
     """
+
     def _recover_nick(self):
         """Recover nick by sending REGAIN command to NickServ."""
         if not self.has_primary_nick():
             self.connection.privmsg(
-                'NickServ', 'REGAIN {}'.format(self._primary_nick))
+                "NickServ",
+                f"REGAIN {self._primary_nick}",
+            )

--- a/tests/bot_test.py
+++ b/tests/bot_test.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # This file is part of IRC Bot Behavior Bundle (IB3)
 # Copyright (C) 2017 Bryan Davis and contributors
 #
@@ -15,26 +13,24 @@
 #
 # You should have received a copy of the GNU General Public License along with
 # this program.  If not, see <http://www.gnu.org/licenses/>.
-import ssl
+
+# Dummy test file that really tests nothing other than that imports succeed
+
+import irc.client
+import jaraco.stream
 
 import ib3
-import ib3.connection
 
 
-class SSLBot(ib3.connection.SSL, ib3.Bot):
-    pass
-
-
-def test_ssl(mocker):
-    mock_init = mocker.patch('irc.bot.SingleServerIRCBot.__init__')
-    conn_factory = mocker.patch('irc.connection.Factory')
-    bot = SSLBot(
-        server_list=[('localhost', '9999')],
-        realname='ib3test',
-        nickname='ib3test',
+def test_construct_sets_lenient_decoding():
+    bot = ib3.Bot(
+        server_list=[("localhost", "9999")],
+        realname="ib3test",
+        nickname="ib3test",
     )
-    assert isinstance(bot, ib3.connection.SSL)
-    assert isinstance(bot, ib3.Bot)
-    conn_factory.assert_called_once_with(wrapper=ssl.wrap_socket)
-    args, kwargs = mock_init.call_args
-    assert kwargs['connect_factory'] is conn_factory.return_value
+    assert bot.servers.peek() is not None
+    assert jaraco.stream.buffer.LenientDecodingLineBuffer.errors == "replace"
+    assert (
+        irc.client.ServerConnection.buffer_class
+        == jaraco.stream.buffer.LenientDecodingLineBuffer
+    )

--- a/tests/connection_test.py
+++ b/tests/connection_test.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # This file is part of IRC Bot Behavior Bundle (IB3)
 # Copyright (C) 2017 Bryan Davis and contributors
 #
@@ -15,19 +13,26 @@
 #
 # You should have received a copy of the GNU General Public License along with
 # this program.  If not, see <http://www.gnu.org/licenses/>.
-
-# Dummy test file that really tests nothing other than that imports succeed
+import ssl
 
 import ib3
-import ib3.auth
 import ib3.connection
-import ib3.mixins
-import ib3.nick
 
-any((
-    ib3,
-    ib3.auth,
-    ib3.connection,
-    ib3.mixins,
-    ib3.nick,
-))  # Ignore unused import warning
+
+class SSLBot(ib3.connection.SSL, ib3.Bot):
+    pass
+
+
+def test_ssl(mocker):
+    mock_init = mocker.patch("irc.bot.SingleServerIRCBot.__init__")
+    conn_factory = mocker.patch("irc.connection.Factory")
+    bot = SSLBot(
+        server_list=[("localhost", "9999")],
+        realname="ib3test",
+        nickname="ib3test",
+    )
+    assert isinstance(bot, ib3.connection.SSL)
+    assert isinstance(bot, ib3.Bot)
+    conn_factory.assert_called_once_with(wrapper=ssl.wrap_socket)
+    args, kwargs = mock_init.call_args
+    assert kwargs["connect_factory"] is conn_factory.return_value

--- a/tests/nothing_test.py
+++ b/tests/nothing_test.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # This file is part of IRC Bot Behavior Bundle (IB3)
 # Copyright (C) 2017 Bryan Davis and contributors
 #
@@ -18,19 +16,18 @@
 
 # Dummy test file that really tests nothing other than that imports succeed
 
-import irc.client
-import jaraco.stream
-
 import ib3
+import ib3.auth
+import ib3.connection
+import ib3.mixins
+import ib3.nick
 
-
-def test_construct_sets_lenient_decoding():
-    bot = ib3.Bot(
-        server_list=[('localhost', '9999')],
-        realname='ib3test',
-        nickname='ib3test',
-    )
-    assert bot.servers.peek() is not None
-    assert jaraco.stream.buffer.LenientDecodingLineBuffer.errors == 'replace'
-    assert irc.client.ServerConnection.buffer_class == \
-        jaraco.stream.buffer.LenientDecodingLineBuffer
+any(
+    (
+        ib3,
+        ib3.auth,
+        ib3.connection,
+        ib3.mixins,
+        ib3.nick,
+    ),
+)  # Ignore unused import warning

--- a/tox.ini
+++ b/tox.ini
@@ -1,23 +1,41 @@
 [tox]
-minversion = 4.0
-envlist = flake8,py37,py38,py39,py310,py311,docs,pkg_meta
+requires =
+    tox>=4.2
+env_list =
+    lint
+    py311
+    py310
+    py39
+    py38
+    py37
+    docs
+    pkg_meta
 skip_missing_interpreters = true
 
 [testenv]
-deps=
+deps =
     pytest
     pytest-cov
     pytest-mock
-setenv=
-    PYTHONDONTWRITEBYTECODE=true
-commands=
+set_env =
+    PYTHONDONTWRITEBYTECODE = true
+commands =
     pytest tests/
 
+[testenv:lint]
+base_python = py311
+deps =
+    pre-commit>=3.2
+commands =
+    pre-commit run --all-files --show-diff-on-failure {posargs}
+    python -c 'print(r"hint: run {envbindir}{/}pre-commit install to add checks as pre-commit hook")'
+escription = format the code base to adhere to our styles, and complain about what we cannot do automatically
+
 [testenv:docs]
-deps=
+deps =
     sphinx
     sphinx_rtd_theme
-commands=
+commands =
     sphinx-build -q -W -b html -d "{envtmpdir}{/}doctree" docs "{toxinidir}{/}dist{/}docs"
     python -c 'print(r"documentation available under file://{toxinidir}{/}dist{/}docs{/}index.html")'
 
@@ -34,13 +52,9 @@ commands =
     twine check --strict {envtmpdir}{/}*
     check-wheel-contents {envtmpdir}
 
-[testenv:flake8]
-base_python = py311
-deps = flake8
-commands =
-    flake8
-
 [flake8]
+exclude = .tox
+max_line_length = 120
 count = 1
 show-pep8 = 1
 show-source = 1
@@ -68,4 +82,4 @@ python =
     3.8 = py38
     3.9 = py39
     3.10 = py310
-    3.11 = flake8, py311, docs, pkg_meta
+    3.11 = lint, py311, docs, pkg_meta


### PR DESCRIPTION
Add a pre-commit configuration to apply a collection of linting and formatting plugins. These will be automatically run by tox in CI, but can also be setup to run as a pre-commit action in the local repo.

Highlights:
* Use black for code formatting
* Use isort for import formatting
* Add a number of flake8 plugins including bugbear